### PR TITLE
Fix cascading setState in auth effect; split Read into rendered + Com…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,47 @@ code, pre, .mono {
 .wiki-content tr:nth-child(even) td { background: var(--surface-raised); }
 .wiki-content a { color: var(--water); text-decoration: underline; }
 .wiki-content hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+.wiki-content del { text-decoration: line-through; color: var(--text-muted); }
+
+/* Wikilinks */
+.wiki-content a.wikilink { color: var(--water); text-decoration: none; border-bottom: 1px dashed rgba(42,111,168,0.45); }
+.wiki-content a.wikilink:hover { border-bottom-style: solid; }
+
+/* Task lists */
+.wiki-content ul.task-list { list-style: none; margin-left: 0.25rem; }
+.wiki-content li.task-open, .wiki-content li.task-done { padding-left: 0.25rem; }
+.wiki-content li.task-done { color: var(--text-muted); text-decoration: line-through; }
+
+/* Callout boxes (Quartz / Obsidian style) */
+.wiki-content .callout { border-radius: 8px; padding: 0.875rem 1rem 0.875rem 1.1rem; margin: 1.25rem 0; border-left: 4px solid var(--border); background: var(--surface-raised); }
+.wiki-content .callout-title { font-weight: 700; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 0.45rem; display: flex; align-items: center; gap: 0.4rem; }
+.wiki-content .callout-body > p:last-child { margin-bottom: 0; }
+.wiki-content .callout-note  { background: rgba(42,111,168,0.07); border-color: var(--water); }
+.wiki-content .callout-note  .callout-title { color: var(--water); }
+.wiki-content .callout-info  { background: rgba(42,111,168,0.07); border-color: var(--water); }
+.wiki-content .callout-info  .callout-title { color: var(--water); }
+.wiki-content .callout-tip   { background: rgba(26,102,65,0.07); border-color: #1a7a50; }
+.wiki-content .callout-tip   .callout-title { color: #1a7a50; }
+.wiki-content .callout-success { background: rgba(26,102,65,0.07); border-color: #1a7a50; }
+.wiki-content .callout-success .callout-title { color: #1a7a50; }
+.wiki-content .callout-warning { background: rgba(201,168,76,0.1); border-color: var(--gold); }
+.wiki-content .callout-warning .callout-title { color: #7a6000; }
+.wiki-content .callout-example { background: rgba(201,168,76,0.1); border-color: var(--gold); }
+.wiki-content .callout-example .callout-title { color: #7a6000; }
+.wiki-content .callout-danger  { background: rgba(153,26,26,0.07); border-color: #b03030; }
+.wiki-content .callout-danger  .callout-title { color: #b03030; }
+.wiki-content .callout-question { background: rgba(153,26,26,0.07); border-color: #b03030; }
+.wiki-content .callout-question .callout-title { color: #b03030; }
+.wiki-content .callout-quote { background: rgba(90,106,126,0.07); border-color: var(--text-muted); font-style: italic; }
+.wiki-content .callout-quote .callout-title { color: var(--text-muted); }
+
+/* Table of Contents */
+.toc { position: sticky; top: 2rem; }
+.toc-title { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 700; color: var(--text-muted); margin-bottom: 0.75rem; padding-left: 0.75rem; }
+.toc-link { display: block; font-size: 0.82rem; color: var(--text-muted); text-decoration: none; padding: 0.22rem 0 0.22rem 0.75rem; border-left: 2px solid transparent; line-height: 1.35; transition: color 0.15s, border-color 0.15s; }
+.toc-link:hover { color: var(--navy); border-left-color: var(--gold); }
+.toc-h1 { font-weight: 600; }
+.toc-h3 { padding-left: 1.5rem; font-size: 0.76rem; }
 
 /* Line highlighting */
 .line-row { display: flex; }

--- a/app/wiki/[slug]/page.tsx
+++ b/app/wiki/[slug]/page.tsx
@@ -1,35 +1,217 @@
 "use client";
-import { useState, useRef } from "react";
+import { useState, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 import { useWikiStore } from "@/lib/store";
 import type { EditSuggestion } from "@/types";
 
-type Tab = "read" | "edit" | "suggest" | "history" | "blame";
+type Tab = "read" | "comments" | "edit" | "suggest" | "history" | "blame";
 
-function renderWikiContent(content: string) {
-  // Simple markdown → HTML renderer
-  let html = content
-    .replace(/^### (.+)$/gm, "<h3>$1</h3>")
-    .replace(/^## (.+)$/gm, "<h2>$1</h2>")
-    .replace(/^# (.+)$/gm, "<h1>$1</h1>")
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>")
-    .replace(/`(.+?)`/g, "<code>$1</code>")
-    .replace(/\[\[(.+?)\]\]/g, "<a href='#'>$1</a>")
-    .replace(/\[(.+?)\]\((.+?)\)/g, "<a href='$2' target='_blank'>$1</a>")
-    .replace(/^- \[ \] (.+)$/gm, "<li style='list-style:none'>☐ $1</li>")
-    .replace(/^- \[x\] (.+)$/gm, "<li style='list-style:none;color:var(--text-muted)'>☑ $1</li>")
-    .replace(/^- (.+)$/gm, "<li>$1</li>")
-    .replace(/^\d+\. (.+)$/gm, "<li>$1</li>")
-    .replace(/^---$/gm, "<hr>")
-    .replace(/\n\n/g, "</p><p>")
-    .replace(/^\|(.+)\|$/gm, (match) => {
-      const cells = match.split("|").slice(1, -1);
-      return "<tr>" + cells.map(c => `<td>${c.trim()}</td>`).join("") + "</tr>";
-    });
+// ─── Markdown renderer ────────────────────────────────────────────────────────
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+}
+
+function renderInline(raw: string): string {
+  let s = raw.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  s = s.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
+  s = s.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  s = s.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  s = s.replace(/~~(.+?)~~/g, "<del>$1</del>");
+  s = s.replace(/`(.+?)`/g, "<code>$1</code>");
+  s = s.replace(/\[\[(.+?)\]\]/g, (_, inner) => {
+    const parts = inner.split("|");
+    const target = parts[0].trim();
+    const label = (parts[1] ?? parts[0]).trim();
+    return `<a class="wikilink" href="/wiki/${slugify(target)}">${label}</a>`;
+  });
+  s = s.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+  return s;
+}
+
+const CALLOUT_ICONS: Record<string, string> = {
+  note: "ℹ", tip: "💡", warning: "⚠", danger: "🔴",
+  info: "ℹ", success: "✓", question: "?", example: "⋮", quote: '"',
+};
+
+function parseTableCells(row: string): string[] {
+  return row.split("|").slice(1, -1).map((c) => c.trim());
+}
+
+function isTableStart(lines: string[], i: number): boolean {
+  return (
+    lines[i].includes("|") &&
+    i + 1 < lines.length &&
+    /^\|[\s\-:|]+\|$/.test(lines[i + 1])
+  );
+}
+
+function renderMarkdown(content: string): string {
+  const lines = content.split("\n");
+  let html = "";
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    if (line.match(/^```/)) {
+      const lang = line.slice(3).trim();
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      html += `<pre><code${lang ? ` class="language-${escHtml(lang)}"` : ""}>${escHtml(codeLines.join("\n"))}</code></pre>`;
+      i++;
+      continue;
+    }
+
+    // Heading
+    const hm = line.match(/^(#{1,3}) (.+)$/);
+    if (hm) {
+      const level = hm[1].length;
+      const text = hm[2].trim();
+      const id = slugify(text);
+      html += `<h${level} id="${id}">${renderInline(text)}</h${level}>`;
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (line.match(/^(-{3,}|\*{3,})$/)) {
+      html += "<hr>";
+      i++;
+      continue;
+    }
+
+    // Blockquote / callout
+    if (line.startsWith("> ") || line === ">") {
+      const bqLines: string[] = [];
+      while (i < lines.length && (lines[i].startsWith("> ") || lines[i] === ">")) {
+        bqLines.push(lines[i].startsWith("> ") ? lines[i].slice(2) : "");
+        i++;
+      }
+      const firstLine = bqLines[0] ?? "";
+      const cm = firstLine.match(/^\[!([\w]+)\]\s*(.*)$/i);
+      if (cm) {
+        const type = cm[1].toLowerCase();
+        const titleText = cm[2].trim() || (type.charAt(0).toUpperCase() + type.slice(1));
+        const icon = CALLOUT_ICONS[type] ?? "📌";
+        const bodyHtml = renderMarkdown(bqLines.slice(1).join("\n"));
+        html += `<div class="callout callout-${escHtml(type)}"><div class="callout-title"><span>${icon}</span> ${escHtml(titleText)}</div><div class="callout-body">${bodyHtml}</div></div>`;
+      } else {
+        html += `<blockquote><p>${renderInline(bqLines.join(" "))}</p></blockquote>`;
+      }
+      continue;
+    }
+
+    // Table
+    if (isTableStart(lines, i)) {
+      const headers = parseTableCells(line);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < lines.length && lines[i].includes("|")) {
+        rows.push(parseTableCells(lines[i]));
+        i++;
+      }
+      html +=
+        "<table><thead><tr>" +
+        headers.map((h) => `<th>${renderInline(h)}</th>`).join("") +
+        "</tr></thead><tbody>" +
+        rows.map((r) => "<tr>" + r.map((c) => `<td>${renderInline(c)}</td>`).join("") + "</tr>").join("") +
+        "</tbody></table>";
+      continue;
+    }
+
+    // Unordered list
+    if (line.match(/^[-*] /)) {
+      let isTask = false;
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^[-*] /)) {
+        const body = lines[i].slice(2);
+        const done = body.match(/^\[x\] (.+)$/i);
+        const open = body.match(/^\[ \] (.+)$/);
+        if (done) {
+          isTask = true;
+          items.push(`<li class="task-done">☑ ${renderInline(done[1])}</li>`);
+        } else if (open) {
+          isTask = true;
+          items.push(`<li class="task-open">☐ ${renderInline(open[1])}</li>`);
+        } else {
+          items.push(`<li>${renderInline(body)}</li>`);
+        }
+        i++;
+      }
+      html += `<ul${isTask ? ' class="task-list"' : ""}>${items.join("")}</ul>`;
+      continue;
+    }
+
+    // Ordered list
+    if (line.match(/^\d+\. /)) {
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^\d+\. /)) {
+        const m = lines[i].match(/^\d+\. (.+)$/);
+        if (m) items.push(`<li>${renderInline(m[1])}</li>`);
+        i++;
+      }
+      html += `<ol>${items.join("")}</ol>`;
+      continue;
+    }
+
+    // Empty line
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Paragraph — collect until a blank line or a block-level starter
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !lines[i].match(/^#{1,6} /) &&
+      !lines[i].match(/^[-*] /) &&
+      !lines[i].match(/^\d+\. /) &&
+      !lines[i].startsWith(">") &&
+      !lines[i].match(/^```/) &&
+      !lines[i].match(/^(-{3,}|\*{3,})$/) &&
+      !isTableStart(lines, i)
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length) {
+      html += `<p>${renderInline(paraLines.join(" "))}</p>`;
+    } else {
+      i++; // guard against infinite loop on unhandled line
+    }
+  }
+
   return html;
 }
+
+function extractToc(content: string): Array<{ level: number; text: string; id: string }> {
+  return content
+    .split("\n")
+    .filter((l) => /^#{1,3} /.test(l))
+    .map((l) => {
+      const m = l.match(/^(#{1,3}) (.+)$/)!;
+      return { level: m[1].length, text: m[2].trim(), id: slugify(m[2].trim()) };
+    });
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function WikiPageView() {
   const params = useParams();
@@ -39,18 +221,27 @@ export default function WikiPageView() {
   const router = useRouter();
 
   const page = getPage(slug);
-  const versions = getVersions(page?.id || "");
-  const comments = getPageComments(page?.id || "");
-  const pageSuggestions = suggestions.filter(s => s.pageId === page?.id);
+  const versions = getVersions(page?.id ?? "");
+  const comments = getPageComments(page?.id ?? "");
+  const pageSuggestions = suggestions.filter((s) => s.pageId === page?.id);
 
   const [tab, setTab] = useState<Tab>("read");
-  const [editContent, setEditContent] = useState(page?.content || "");
+  const [editContent, setEditContent] = useState(page?.content ?? "");
   const [editMessage, setEditMessage] = useState("");
-  const [suggestContent, setSuggestContent] = useState(page?.content || "");
+  const [suggestContent, setSuggestContent] = useState(page?.content ?? "");
   const [suggestMessage, setSuggestMessage] = useState("");
   const [commentLine, setCommentLine] = useState<number | null>(null);
   const [commentBody, setCommentBody] = useState("");
   const [saved, setSaved] = useState(false);
+
+  // Strip the leading H1 since the page title is already shown above the tabs
+  const contentBody = useMemo(
+    () => (page ? page.content.replace(/^# [^\n]*\n?/, "") : ""),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [page?.content]
+  );
+  const renderedHtml = useMemo(() => renderMarkdown(contentBody), [contentBody]);
+  const toc = useMemo(() => extractToc(contentBody), [contentBody]);
 
   if (!page) return (
     <div style={{ padding: "3rem", color: "var(--text-muted)" }}>
@@ -62,10 +253,12 @@ export default function WikiPageView() {
 
   const lines = page.content.split("\n");
   const lineCommentMap: Record<number, typeof comments> = {};
-  comments.forEach(c => {
+  comments.forEach((c) => {
     if (!lineCommentMap[c.lineNumber]) lineCommentMap[c.lineNumber] = [];
     lineCommentMap[c.lineNumber].push(c);
   });
+
+  const openCommentCount = comments.filter((c) => !c.resolved).length;
 
   function handleSave() {
     if (!editMessage.trim()) return;
@@ -93,7 +286,7 @@ export default function WikiPageView() {
     if (!commentBody.trim() || commentLine === null) return;
     addComment({
       pageId: page!.id, lineNumber: commentLine,
-      lineContent: lines[commentLine - 1] || "",
+      lineContent: lines[commentLine - 1] ?? "",
       authorId: user!.id, authorName: user!.name, authorRole: user!.role,
       body: commentBody, resolved: false,
     });
@@ -103,13 +296,14 @@ export default function WikiPageView() {
 
   const TABS: { id: Tab; label: string }[] = [
     { id: "read", label: "Read" },
+    { id: "comments", label: openCommentCount > 0 ? `Comments (${openCommentCount})` : "Comments" },
     { id: "blame", label: "Blame" },
     { id: "history", label: `History (${versions.length})` },
     ...(canEdit ? [{ id: "edit" as Tab, label: "Edit" }] : [{ id: "suggest" as Tab, label: "Suggest Edit" }]),
   ];
 
   return (
-    <div style={{ padding: "2rem 3rem", maxWidth: 1000 }}>
+    <div style={{ padding: "2rem 3rem", maxWidth: 1100 }}>
       {/* Breadcrumb */}
       <div style={{ fontSize: "0.8rem", color: "var(--text-muted)", marginBottom: "1rem" }}>
         <span style={{ cursor: "pointer", color: "var(--water)" }} onClick={() => router.push("/wiki")}>Wiki</span>
@@ -123,7 +317,7 @@ export default function WikiPageView() {
       <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "1rem", marginBottom: "0.75rem" }}>
         <h1 style={{ fontFamily: "'DM Serif Display', serif", fontSize: "2rem", color: "var(--navy)" }}>{page.title}</h1>
         <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0, marginTop: "0.4rem" }}>
-          {page.tags.map(t => (
+          {page.tags.map((t) => (
             <span key={t} style={{ fontSize: "0.7rem", background: "var(--surface-raised)", color: "var(--text-muted)", padding: "3px 8px", borderRadius: 99, border: "1px solid var(--border)" }}>{t}</span>
           ))}
         </div>
@@ -134,7 +328,7 @@ export default function WikiPageView() {
         <span>By <strong>{page.authorName}</strong></span>
         <span>v{page.version}</span>
         <span>Updated {page.updatedAt}</span>
-        <span>{pageSuggestions.filter(s => s.status === "open").length} open suggestion{pageSuggestions.filter(s => s.status === "open").length !== 1 ? "s" : ""}</span>
+        <span>{pageSuggestions.filter((s) => s.status === "open").length} open suggestion{pageSuggestions.filter((s) => s.status === "open").length !== 1 ? "s" : ""}</span>
       </div>
 
       {/* YouTube links */}
@@ -143,8 +337,8 @@ export default function WikiPageView() {
           <span style={{ fontSize: "1.5rem" }}>▶️</span>
           <div>
             <div style={{ color: "var(--gold)", fontSize: "0.75rem", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Related Videos</div>
-            {page.youtubeLinks.map((url, i) => (
-              <a key={i} href={url} target="_blank" rel="noopener noreferrer" style={{ color: "white", fontSize: "0.875rem", display: "block" }}>Watch on YouTube →</a>
+            {page.youtubeLinks.map((url, idx) => (
+              <a key={idx} href={url} target="_blank" rel="noopener noreferrer" style={{ color: "white", fontSize: "0.875rem", display: "block" }}>Watch on YouTube →</a>
             ))}
           </div>
         </div>
@@ -152,7 +346,7 @@ export default function WikiPageView() {
 
       {/* Tab bar */}
       <div style={{ display: "flex", gap: "0.25rem", borderBottom: "2px solid var(--border)", marginBottom: "1.5rem" }}>
-        {TABS.map(t => (
+        {TABS.map((t) => (
           <button key={t.id} onClick={() => setTab(t.id)}
             style={{ padding: "0.5rem 1rem", border: "none", background: "none", cursor: "pointer", fontFamily: "'DM Sans', sans-serif", fontSize: "0.875rem", fontWeight: tab === t.id ? 600 : 400, color: tab === t.id ? "var(--navy)" : "var(--text-muted)", borderBottom: tab === t.id ? "2px solid var(--navy)" : "2px solid transparent", marginBottom: "-2px", transition: "color 0.15s" }}>
             {t.label}
@@ -160,30 +354,63 @@ export default function WikiPageView() {
         ))}
       </div>
 
-      {/* READ TAB */}
+      {/* ── READ TAB — Quartz / Obsidian style ── */}
       {tab === "read" && (
+        <div className="fade-in" style={{ display: "flex", gap: "3rem", alignItems: "flex-start" }}>
+          {/* Rendered article */}
+          <div
+            className="wiki-content"
+            style={{ flex: 1, minWidth: 0 }}
+            dangerouslySetInnerHTML={{ __html: renderedHtml }}
+          />
+
+          {/* Table of contents */}
+          {toc.length > 1 && (
+            <nav className="toc" style={{ width: 196, flexShrink: 0 }}>
+              <div className="toc-title">On this page</div>
+              {toc.map((item, idx) => (
+                <a key={idx} href={`#${item.id}`} className={`toc-link toc-h${item.level}`}>
+                  {item.text}
+                </a>
+              ))}
+            </nav>
+          )}
+        </div>
+      )}
+
+      {/* ── COMMENTS TAB ── */}
+      {tab === "comments" && (
         <div className="fade-in">
           <div style={{ display: "flex", gap: "2rem" }}>
-            {/* Line-annotated content */}
+            {/* Line-annotated source */}
             <div style={{ flex: 1 }}>
+              <p style={{ fontSize: "0.82rem", color: "var(--text-muted)", marginBottom: "1rem" }}>
+                Click any line number to leave a comment on that line.
+              </p>
               <div style={{ fontFamily: "'DM Mono', monospace", fontSize: "0.875rem", lineHeight: "1.7" }}>
                 {lines.map((line, idx) => {
                   const lineNum = idx + 1;
-                  const lineComments = lineCommentMap[lineNum] || [];
+                  const lineComments = lineCommentMap[lineNum] ?? [];
                   const hasComment = lineComments.length > 0;
                   return (
                     <div key={idx}>
                       <div className="line-row">
                         <span className="line-number" onClick={() => setCommentLine(commentLine === lineNum ? null : lineNum)} title="Click to comment">{lineNum}</span>
-                        <span className={`line-content ${hasComment ? "has-comment" : ""} ${commentLine === lineNum ? "highlighted" : ""}`} onClick={() => setCommentLine(commentLine === lineNum ? null : lineNum)}>
+                        <span
+                          className={`line-content ${hasComment ? "has-comment" : ""} ${commentLine === lineNum ? "highlighted" : ""}`}
+                          onClick={() => setCommentLine(commentLine === lineNum ? null : lineNum)}
+                        >
                           {line || " "}
                         </span>
                         {hasComment && (
-                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "var(--gold)", alignSelf: "center" }}>💬 {lineComments.filter(c => !c.resolved).length}</span>
+                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "var(--gold)", alignSelf: "center" }}>
+                            💬 {lineComments.filter((c) => !c.resolved).length}
+                          </span>
                         )}
                       </div>
+
                       {/* Inline comment thread */}
-                      {hasComment && lineComments.filter(c => !c.resolved).map(c => (
+                      {hasComment && lineComments.filter((c) => !c.resolved).map((c) => (
                         <div key={c.id} style={{ display: "flex", gap: "0.75rem", background: "rgba(201,168,76,0.08)", borderLeft: "3px solid var(--gold)", padding: "0.6rem 0.75rem 0.6rem 2.75rem", margin: "0.15rem 0" }}>
                           <div style={{ flex: 1 }}>
                             <div style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
@@ -198,11 +425,17 @@ export default function WikiPageView() {
                           )}
                         </div>
                       ))}
-                      {/* Comment input box */}
+
+                      {/* Comment input */}
                       {commentLine === lineNum && (
                         <div style={{ display: "flex", gap: "0.5rem", padding: "0.5rem 0.5rem 0.5rem 2.5rem", background: "var(--gold-pale)", borderLeft: "3px solid var(--water)" }}>
-                          <textarea value={commentBody} onChange={e => setCommentBody(e.target.value)} placeholder="Add a comment on this line…" rows={2}
-                            style={{ flex: 1, padding: "0.5rem 0.75rem", border: "1px solid var(--border)", borderRadius: 6, fontSize: "0.82rem", fontFamily: "'DM Sans', sans-serif", resize: "vertical", outline: "none" }} />
+                          <textarea
+                            value={commentBody}
+                            onChange={(e) => setCommentBody(e.target.value)}
+                            placeholder="Add a comment on this line…"
+                            rows={2}
+                            style={{ flex: 1, padding: "0.5rem 0.75rem", border: "1px solid var(--border)", borderRadius: 6, fontSize: "0.82rem", fontFamily: "'DM Sans', sans-serif", resize: "vertical", outline: "none" }}
+                          />
                           <div style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}>
                             <button onClick={handleAddComment} style={{ padding: "0.4rem 0.75rem", background: "var(--navy)", color: "var(--gold)", border: "none", borderRadius: 6, fontSize: "0.75rem", fontWeight: 600, cursor: "pointer" }}>Post</button>
                             <button onClick={() => setCommentLine(null)} style={{ padding: "0.4rem 0.75rem", background: "none", color: "var(--text-muted)", border: "1px solid var(--border)", borderRadius: 6, fontSize: "0.75rem", cursor: "pointer" }}>Cancel</button>
@@ -215,11 +448,11 @@ export default function WikiPageView() {
               </div>
             </div>
 
-            {/* Right sidebar — page suggestions */}
+            {/* Suggestions sidebar */}
             {pageSuggestions.length > 0 && (
               <div style={{ width: 240, flexShrink: 0 }}>
                 <div style={{ fontSize: "0.7rem", textTransform: "uppercase", letterSpacing: "0.08em", fontWeight: 600, color: "var(--text-muted)", marginBottom: "0.75rem" }}>Suggestions</div>
-                {pageSuggestions.map(s => (
+                {pageSuggestions.map((s) => (
                   <div key={s.id} style={{ background: "white", border: "1px solid var(--border)", borderRadius: 8, padding: "0.75rem", marginBottom: "0.5rem" }}>
                     <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.4rem" }}>
                       <span style={{ fontSize: "0.75rem", fontWeight: 600 }}>{s.authorName}</span>
@@ -235,16 +468,15 @@ export default function WikiPageView() {
         </div>
       )}
 
-      {/* BLAME TAB */}
+      {/* ── BLAME TAB ── */}
       {tab === "blame" && (
         <div className="fade-in">
           <p style={{ fontSize: "0.82rem", color: "var(--text-muted)", marginBottom: "1rem" }}>Git blame shows who last modified each part of this article.</p>
           <div style={{ fontFamily: "'DM Mono', monospace", fontSize: "0.82rem", lineHeight: "1.7" }}>
             {lines.map((line, idx) => {
               const lineNum = idx + 1;
-              // Simulate blame by attributing lines to versions
               const vIdx = Math.floor((idx / lines.length) * Math.max(versions.length, 1));
-              const ver = versions[vIdx] || { authorName: page.authorName, authorRole: page.authorId === "u1" ? "coach" : "athlete", createdAt: page.createdAt, version: 1 };
+              const ver = versions[vIdx] ?? { authorName: page.authorName, authorRole: page.authorId === "u1" ? "coach" : "athlete", createdAt: page.createdAt, version: 1 };
               return (
                 <div key={idx} className="line-row" style={{ borderBottom: "1px solid rgba(0,0,0,0.03)" }}>
                   <span style={{ minWidth: "1.8rem", color: "var(--text-muted)", textAlign: "right", padding: "0 0.4rem", fontSize: "0.72rem" }}>{lineNum}</span>
@@ -259,7 +491,7 @@ export default function WikiPageView() {
         </div>
       )}
 
-      {/* HISTORY TAB */}
+      {/* ── HISTORY TAB ── */}
       {tab === "history" && (
         <div className="fade-in">
           {versions.length === 0 && <p style={{ color: "var(--text-muted)" }}>No version history yet.</p>}
@@ -280,20 +512,20 @@ export default function WikiPageView() {
         </div>
       )}
 
-      {/* EDIT TAB (coaches/captains) */}
+      {/* ── EDIT TAB (coaches / captains) ── */}
       {tab === "edit" && canEdit && (
         <div className="fade-in">
           <p style={{ fontSize: "0.82rem", color: "var(--text-muted)", marginBottom: "1rem" }}>You have editor access. Changes are saved with a commit message.</p>
-          <textarea value={editContent} onChange={e => setEditContent(e.target.value)} rows={24}
+          <textarea value={editContent} onChange={(e) => setEditContent(e.target.value)} rows={24}
             style={{ width: "100%", fontFamily: "'DM Mono', monospace", fontSize: "0.85rem", padding: "1rem", border: "1.5px solid var(--border)", borderRadius: 8, outline: "none", resize: "vertical", lineHeight: "1.6", background: "var(--navy)", color: "#c8d8e8" }}
-            onFocus={e => (e.target.style.borderColor = "var(--gold)")}
-            onBlur={e => (e.target.style.borderColor = "var(--border)")}
+            onFocus={(e) => (e.target.style.borderColor = "var(--gold)")}
+            onBlur={(e) => (e.target.style.borderColor = "var(--border)")}
           />
           <div style={{ display: "flex", gap: "0.75rem", marginTop: "1rem", alignItems: "center" }}>
-            <input value={editMessage} onChange={e => setEditMessage(e.target.value)} placeholder="Commit message (e.g. 'Updated catch section from practice notes')"
+            <input value={editMessage} onChange={(e) => setEditMessage(e.target.value)} placeholder="Commit message (e.g. 'Updated catch section from practice notes')"
               style={{ flex: 1, padding: "0.65rem 1rem", border: "1.5px solid var(--border)", borderRadius: 8, fontSize: "0.875rem", fontFamily: "'DM Sans', sans-serif", outline: "none" }}
-              onFocus={e => (e.target.style.borderColor = "var(--water)")}
-              onBlur={e => (e.target.style.borderColor = "var(--border)")} />
+              onFocus={(e) => (e.target.style.borderColor = "var(--water)")}
+              onBlur={(e) => (e.target.style.borderColor = "var(--border)")} />
             <button onClick={handleSave} disabled={!editMessage.trim()}
               style={{ padding: "0.65rem 1.5rem", background: !editMessage.trim() ? "var(--border)" : "var(--navy)", color: "var(--gold)", border: "none", borderRadius: 8, fontWeight: 600, cursor: editMessage.trim() ? "pointer" : "not-allowed", fontFamily: "'DM Sans', sans-serif", whiteSpace: "nowrap" }}>
               {saved ? "Saved ✓" : "Save Changes"}
@@ -302,16 +534,16 @@ export default function WikiPageView() {
         </div>
       )}
 
-      {/* SUGGEST TAB (athletes) */}
+      {/* ── SUGGEST TAB (athletes) ── */}
       {tab === "suggest" && !canEdit && (
         <div className="fade-in">
           <div style={{ background: "var(--gold-pale)", border: "1px solid var(--gold)", borderRadius: 8, padding: "0.75rem 1rem", marginBottom: "1rem", fontSize: "0.82rem" }}>
             <strong>Suggesting an edit:</strong> Your suggestion will be reviewed by a coach or captain before being merged.
           </div>
-          <textarea value={suggestContent} onChange={e => setSuggestContent(e.target.value)} rows={24}
+          <textarea value={suggestContent} onChange={(e) => setSuggestContent(e.target.value)} rows={24}
             style={{ width: "100%", fontFamily: "'DM Mono', monospace", fontSize: "0.85rem", padding: "1rem", border: "1.5px solid var(--border)", borderRadius: 8, outline: "none", resize: "vertical", lineHeight: "1.6", background: "var(--navy)", color: "#c8d8e8" }} />
           <div style={{ display: "flex", gap: "0.75rem", marginTop: "1rem", alignItems: "center" }}>
-            <input value={suggestMessage} onChange={e => setSuggestMessage(e.target.value)} placeholder="Describe your change and why you're suggesting it"
+            <input value={suggestMessage} onChange={(e) => setSuggestMessage(e.target.value)} placeholder="Describe your change and why you're suggesting it"
               style={{ flex: 1, padding: "0.65rem 1rem", border: "1.5px solid var(--border)", borderRadius: 8, fontSize: "0.875rem", fontFamily: "'DM Sans', sans-serif", outline: "none" }} />
             <button onClick={handleSuggest} disabled={!suggestMessage.trim()}
               style={{ padding: "0.65rem 1.5rem", background: !suggestMessage.trim() ? "var(--border)" : "var(--water)", color: "white", border: "none", borderRadius: 8, fontWeight: 600, cursor: suggestMessage.trim() ? "pointer" : "not-allowed", fontFamily: "'DM Sans', sans-serif", whiteSpace: "nowrap" }}>

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import React, { createContext, useContext, useReducer, useEffect, useCallback } from "react";
 import type { User, Role } from "@/types";
 import { MOCK_USERS } from "@/lib/data";
 
@@ -17,29 +17,42 @@ const AuthContext = createContext<AuthContextType | null>(null);
 const EDIT_ROLES: Role[] = ["coach", "captain", "admin"];
 const ADMIN_ROLES: Role[] = ["admin"];
 
+type AuthState = { user: User | null; loading: boolean };
+type AuthAction =
+  | { type: "init"; user: User | null }
+  | { type: "set_user"; user: User | null };
+
+function authReducer(state: AuthState, action: AuthAction): AuthState {
+  switch (action.type) {
+    case "init": return { user: action.user, loading: false };
+    case "set_user": return { ...state, user: action.user };
+    default: return state;
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [{ user, loading }, dispatch] = useReducer(authReducer, { user: null, loading: true });
 
   useEffect(() => {
+    let initialUser: User | null = null;
     try {
       const stored = localStorage.getItem("crewwiki_user");
-      if (stored) setUser(JSON.parse(stored));
+      if (stored) initialUser = JSON.parse(stored);
     } catch {}
-    setLoading(false);
+    dispatch({ type: "init", user: initialUser });
   }, []);
 
   const login = useCallback(async (email: string, _password: string) => {
     // Demo: match by email, any password accepted
     const found = MOCK_USERS.find(u => u.email.toLowerCase() === email.toLowerCase());
     if (!found) return { success: false, error: "No account found with that email." };
-    setUser(found);
+    dispatch({ type: "set_user", user: found });
     localStorage.setItem("crewwiki_user", JSON.stringify(found));
     return { success: true };
   }, []);
 
   const logout = useCallback(() => {
-    setUser(null);
+    dispatch({ type: "set_user", user: null });
     localStorage.removeItem("crewwiki_user");
   }, []);
 


### PR DESCRIPTION
…ments tabs

- Replace dual useState setters in AuthProvider's init effect with a single useReducer dispatch, fixing the Next.js 16 "setState in effect" lint error. Both user and loading now update atomically in one render.

- Split the wiki article Read tab into two tabs: Read: Quartz/Obsidian-style rendered markdown with a sticky ToC sidebar, proper block parser (fenced code, tables, lists, task lists, blockquotes, callouts), and wikilink support. Comments: the existing line-annotation UI, inline threads, and suggestions sidebar moved here.

- Add CSS for callouts, wikilinks, task lists, and the ToC component.